### PR TITLE
Add SSL support to dev static command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ $ dev init
 $ dev static
 $ dev static --port=7788
 $ dev static --dir=./src
+$ dev static --ssl --ssl-cert=path/to/cert.pem --ssl-key=path/to/key.pem
 ```
 * 默认端口：12777，可以通过 `--port` 参数指定
 * 默认目录：当前执行目录，可以通过 `--dir` 参数指定
 * 此服务默认携带 CORS 跨域支持
+* 支持 `--ssl` 参数来启用 HTTPS，使用 `--ssl-cert` 和 `--ssl-key` 参数来指定 SSL 证书和密钥文件的路径
 
 
 ### where 命令：查找本地的全局命令位置


### PR DESCRIPTION
Related to #38

Add support for SSL in the `dev static` command.

* **packages/dev/src/static.ts**
  - Add logic to handle the `--ssl` parameter in the `hanldeLocalServer` method.
  - Add logic to handle the `--ssl-cert` and `--ssl-key` parameters in the `hanldeLocalServer` method.
  - Configure the `koa` server for HTTPS if the `--ssl` parameter is provided.
  - Update the `koa` server to use the provided certificate and key files for HTTPS.
  - Use default certificate and key files if `--ssl-cert` and `--ssl-key` are not provided.

* **README.md**
  - Update the documentation for the `dev static` command to include the `--ssl`, `--ssl-cert`, and `--ssl-key` parameters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/echosoar/make-dev-fast/issues/38?shareId=7f357608-9d6e-4afe-b81e-5701f84151a1).